### PR TITLE
장바구니 페이지 기능 연동 및 알람 수정

### DIFF
--- a/lib/product_model.dart
+++ b/lib/product_model.dart
@@ -12,6 +12,21 @@ class Product {
   });
 }
 
+class CartItem {
+  final Product product;
+  int number;
+
+  CartItem({required this.product, required this.number});
+}
+
+class Cart {
+  static final Cart instance = Cart._internal();
+
+  Cart._internal();
+
+  final List<CartItem> items = [];
+}
+
 class ProductList {
   static final ProductList instance = ProductList._internal();
 
@@ -79,4 +94,14 @@ class ProductList {
       description: "",
     ),
   ];
+
+  // 검색 기능 메서드
+  List<Product> searchProducts(String query) {
+    if (query.isEmpty) return products;
+
+    return products.where((product) {
+      return product.name.toLowerCase().contains(query.toLowerCase()) ||
+          product.description.toLowerCase().contains(query.toLowerCase());
+    }).toList();
+  }
 }

--- a/lib/screen/cart_page.dart
+++ b/lib/screen/cart_page.dart
@@ -1,0 +1,136 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart'; //가격 포맷팅(세자리마다쉼표)
+//import 'package:flutter_spinbox/flutter_spinbox.dart'; //수량조절
+import '../product_model.dart';
+import '../widget/cart_item_tile.dart';
+import '../screen/product_list_page.dart';
+
+class CartPage extends StatefulWidget {
+  final Product? product;
+  final int? number;
+
+  const CartPage({super.key, this.product, this.number});
+
+  @override
+  State<CartPage> createState() => _CartPageState();
+}
+
+class _CartPageState extends State<CartPage> {
+  Cart cart = Cart.instance;
+
+  @override
+  void initState() {
+    super.initState();
+    if (widget.product != null && widget.number != null) {
+      cart.items.add(
+        CartItem(product: widget.product!, number: widget.number!),
+      );
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    int totalPrice = 0;
+    for (int i = 0; i < cart.items.length; i++) {
+      totalPrice += cart.items[i].product.price * cart.items[i].number;
+    }
+    final formattedTotalPrice = NumberFormat('#,###').format(totalPrice);
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        title: const Text(
+          'Grab it',
+          style: TextStyle(fontWeight: FontWeight.bold),
+        ),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          Expanded(
+            child: cart.items.isEmpty
+                ? const Center(child: Text('장바구니가 비었습니다.'))
+                : ListView.builder(
+                    itemCount: cart.items.length,
+                    itemBuilder: (context, index) {
+                      return CartItemTile(
+                        product: cart.items[index].product,
+                        quantity: cart.items[index].number,
+                        onAdd: () {
+                          setState(() {
+                            cart.items[index].number++;
+                          });
+                        },
+                        onRemove: cart.items[index].number > 1
+                            ? () {
+                                setState(() {
+                                  cart.items[index].number--;
+                                });
+                              }
+                            : null,
+                        onDelete: () {
+                          setState(() {
+                            cart.items.removeAt(index);
+                          });
+                        },
+                      );
+                    },
+                  ),
+          ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 4),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: Text(
+                '총 금액: $formattedTotalPrice원',
+                style: const TextStyle(
+                  fontSize: 18,
+                  fontWeight: FontWeight.bold,
+                  color: Colors.black87,
+                ),
+              ),
+            ),
+          ),
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 50),
+            child: SizedBox(
+              width: double.infinity,
+              height: 48,
+              child: ElevatedButton(
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: cart.items.isEmpty
+                      ? Colors.grey
+                      : Colors.blueGrey,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(10),
+                  ),
+                ),
+                onPressed: () {
+                  if (cart.items.isEmpty) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('장바구니가 비었습니다.')),
+                    );
+                  } else {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => ProductListPage(),
+                      ),
+                    );
+                  }
+                },
+                child: const Text(
+                  '구매하기',
+                  style: TextStyle(
+                    color: Colors.white,
+                    fontSize: 18,
+                    fontWeight: FontWeight.bold,
+                  ),
+                ),
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screen/product_add_page.dart
+++ b/lib/screen/product_add_page.dart
@@ -74,7 +74,7 @@ class _ProductAddPageState extends State<ProductAddPage> {
   Widget build(BuildContext context) {
     return Scaffold(
       backgroundColor: Theme.of(context).colorScheme.surface,
-      appBar: AppBar(title: const Text('상품 등록'), leading: BackButton()),
+      appBar: AppBar(title: const Text('Grab it'), leading: BackButton()),
       body: SingleChildScrollView(
         padding: const EdgeInsets.all(20),
         child: Form(

--- a/lib/screen/product_detail_page.dart
+++ b/lib/screen/product_detail_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'dart:io';
 import '../product_model.dart';
 import 'package:intl/intl.dart';
+import 'cart_page.dart';
 
 class ProductDetailPage extends StatefulWidget {
   const ProductDetailPage({super.key, required this.product});
@@ -13,10 +14,10 @@ class ProductDetailPage extends StatefulWidget {
   State<ProductDetailPage> createState() => _ProductDetailPageState();
 }
 
-int totalPrice = 0;
-int number = 0;
-
 class _ProductDetailPageState extends State<ProductDetailPage> {
+  int number = 0;
+  int totalPrice = 0;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -62,9 +63,9 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 NumberButton(
-                  onChanged: (number) {
+                  onChanged: (n) {
                     setState(() {
-                      number = number;
+                      number = n;
                       totalPrice = widget.product.price * number;
                     });
                   },
@@ -77,16 +78,54 @@ class _ProductDetailPageState extends State<ProductDetailPage> {
                     foregroundColor: Colors.white,
                   ),
                   onPressed: () {
-                    // TODO: 장바구니 담기 기능 구현
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('장바구니에 담았습니다.')),
-                    );
-                    // Navigator.push(
-                    //   context,
-                    //   MaterialPageRoute(
-                    //     builder: (context) => const ProductAddPage(),
-                    //   ),
-                    // );
+                    if (number > 0) {
+                      showDialog(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: Text(
+                            '${widget.product.name}을 ${number.toString()}개 구매하시겠습니까?',
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () {
+                                Navigator.pop(context);
+                              },
+                              child: Text(
+                                '취소',
+                                style: TextStyle(color: Colors.red),
+                              ),
+                            ),
+                            TextButton(
+                              onPressed: () {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                    content: Text('장바구니에 담았습니다.'),
+                                    duration: Duration(seconds: 2),
+                                  ),
+                                );
+                                Navigator.pushReplacement(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (context) => CartPage(
+                                      product: widget.product,
+                                      number: number,
+                                    ),
+                                  ),
+                                );
+                              },
+                              child: Text(
+                                '확인',
+                                style: TextStyle(color: Colors.green),
+                              ),
+                            ),
+                          ],
+                        ),
+                      );
+                    } else {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        const SnackBar(content: Text('구매 수량을 입력해주세요.')),
+                      );
+                    }
                   },
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/screen/product_list_page.dart
+++ b/lib/screen/product_list_page.dart
@@ -3,6 +3,9 @@ import 'package:intl/intl.dart';
 import '../product_model.dart';
 import '../screen/product_detail_page.dart';
 import '../screen/product_add_page.dart';
+import 'package:iconsax/iconsax.dart';
+import '../screen/cart_page.dart';
+import '../widget/product_search_delegate.dart';
 
 class ProductListPage extends StatelessWidget {
   final ProductList productList = ProductList.instance;
@@ -19,6 +22,17 @@ class ProductListPage extends StatelessWidget {
           style: TextStyle(fontWeight: FontWeight.bold),
         ),
         centerTitle: true,
+        actions: [
+          IconButton(
+            icon: Icon(Iconsax.shopping_cart),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => CartPage()),
+              );
+            },
+          ),
+        ],
       ),
       body: Stack(
         children: [
@@ -98,7 +112,12 @@ class ProductListPage extends StatelessWidget {
               children: [
                 FloatingActionButton(
                   heroTag: 'search',
-                  onPressed: () {},
+                  onPressed: () {
+                    showSearch(
+                      context: context,
+                      delegate: ProductSearchDelegate(productList.products),
+                    );
+                  },
                   shape: const CircleBorder(),
                   backgroundColor: Colors.grey[200],
                   child: Icon(Icons.search, size: 28),

--- a/lib/widget/cart_item_tile.dart
+++ b/lib/widget/cart_item_tile.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../product_model.dart';
+
+class CartItemTile extends StatelessWidget {
+  final Product product;
+  final int quantity;
+  final VoidCallback? onAdd;
+  final VoidCallback? onRemove;
+  final VoidCallback? onDelete;
+
+  const CartItemTile({
+    super.key,
+    required this.product,
+    required this.quantity,
+    this.onAdd,
+    this.onRemove,
+    this.onDelete,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Stack(
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(vertical: 8, horizontal: 16),
+              child: Row(
+                children: [
+                  Image(
+                    image: AssetImage(product.imageUrl),
+                    width: 120,
+                    height: 160,
+                  ),
+                  const SizedBox(width: 20),
+                  Expanded(
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(
+                          product.name,
+                          style: TextStyle(
+                            fontSize: 16,
+                            fontWeight: FontWeight.bold,
+                          ),
+                        ),
+                        Text('${NumberFormat('#,###').format(product.price)}원'),
+                        Row(
+                          children: [
+                            IconButton(
+                              icon: Icon(Icons.remove),
+                              onPressed: onRemove,
+                            ),
+                            Text(' $quantity'),
+                            IconButton(icon: Icon(Icons.add), onPressed: onAdd),
+                          ],
+                        ),
+                      ],
+                    ),
+                  ),
+                ],
+              ),
+            ),
+            Positioned(
+              top: 0,
+              right: 0,
+              child: IconButton(
+                icon: Icon(Icons.close, color: Colors.grey),
+                onPressed: onDelete,
+                tooltip: '삭제',
+              ),
+            ),
+          ],
+        ),
+        Divider(),
+      ],
+    );
+  }
+}

--- a/lib/widget/product_search_delegate.dart
+++ b/lib/widget/product_search_delegate.dart
@@ -1,0 +1,50 @@
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../product_model.dart';
+
+class ProductSearchDelegate extends SearchDelegate {
+  final List<Product> products;
+
+  ProductSearchDelegate(this.products);
+
+  @override
+  List<Widget>? buildActions(BuildContext context) {
+    return [IconButton(icon: Icon(Icons.clear), onPressed: () => query = '')];
+  }
+
+  @override
+  Widget? buildLeading(BuildContext context) {
+    return IconButton(
+      icon: Icon(Icons.arrow_back),
+      onPressed: () => close(context, null),
+    );
+  }
+
+  @override
+  Widget buildResults(BuildContext context) {
+    final results = products
+        .where((p) => p.name.toLowerCase().contains(query.toLowerCase()))
+        .toList();
+
+    if (results.isEmpty) {
+      return Center(child: Text('검색 결과가 없습니다.'));
+    }
+
+    return ListView(
+      children: results
+          .map(
+            (p) => ListTile(
+              title: Text(p.name),
+              subtitle: Text('${NumberFormat('#,###').format(p.price)}원'),
+              leading: Image.asset(p.imageUrl, width: 40, height: 40),
+            ),
+          )
+          .toList(),
+    );
+  }
+
+  @override
+  Widget buildSuggestions(BuildContext context) {
+    return buildResults(context);
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -144,6 +144,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  iconsax:
+    dependency: "direct main"
+    description:
+      name: iconsax
+      sha256: fb0144c61f41f3f8a385fadc27783ea9f5359670be885ed7f35cef32565d5228
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.8"
   image_picker:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dependencies:
   cupertino_icons: ^1.0.8
   intl: ^0.20.2
   image_picker: ^1.0.7
+  iconsax: ^0.0.8
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### ✨ 변경 사항 (What)
- `CartPage`(장바구니 페이지)와 상품 선택 로직 연동
- 수량 선택 시 SnackBar → AlertDialog로 UI 개선
- 장바구니에 상품 추가 후 사용자에게 알림 표시


### 📌 이유 및 목적 (Why)
- 장바구니 페이지와 실제 상품 선택 기능이 연결되어 있지 않아, UX에 단절감이 있었음
- SnackBar의 버튼이 1개만 가능해 "취소" 버튼을 제공하지 못함 → AlertDialog로 UX 개선

### 🧪 테스트 및 확인 사항 (How)
- 수량 선택 후 "확인"을 누르면 장바구니에 정상 추가됨
- AlertDialog에서 "취소"/"확인" 선택 시 동작 구분 가능
- 동일 상품 여러 번 추가 시 누적 처리 되는 구조
